### PR TITLE
Issue#3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,7 @@ Also see the examples/profile.pp file for an example on how to set up dependenci
   class { 'razor':
     db_hostname => '127.0.0.1',
     db_password => 'notasecretpassword',
+    server_http_port => '8150',
   } 
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@
 # * server_config_file (string): See Params
 # * server_service_name (string): See Params
 # * microkernel_url (string): See Params
+# * server_http_port (string): See Params
+# * server_https_port (string): See Params
 #
 # (*) It is highly recommended to put secret keys in Hiera-eyaml and use automatic parameter lookup
 # [https://github.com/TomPoulton/hiera-eyaml]
@@ -64,6 +66,8 @@ class razor (
   $torquebox_package_version  = 'present',
   $server_config_file         = $razor::params::server_config_file,
   $server_service_name        = $razor::params::server_service_name,
+  $server_http_port           = $razor::params::server_http_port,
+  $server_https_port          = $razor::params::server_https_port,
 
   # TFTP
   $server_hostname          = $::ipaddress,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,8 @@
 #   * server_service_name (string): Name of the service that manages Razor Server
 #   * microkernel_url (string): URL of where to download Microkernel (tarball). Set undef to skip.
 #   * repo_store (string): Path where microkernel and OS images are stored.
+#   * server_http_port (string): HTTP server port name/number
+#   * server_https_port (string): HTTPS server port name/number
 #
 class razor::params {
   $client_package_name = 'razor-client'
@@ -21,4 +23,6 @@ class razor::params {
 
   $microkernel_url = 'http://links.puppetlabs.com/razor-microkernel-latest.tar'
   $repo_store = '/var/lib/razor/repo-store/'
+  $server_http_port = '8080'
+  $server_https_port = '8081'
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -69,10 +69,10 @@ class razor::server inherits razor {
               # EL 6.0 - 6.5 - OK
             }
             '7': {
-              fail("CentOS/RHEL 7 is not supported yet ${::operatingsystem}")
+              # EL 7.1 - OK
             }
             default: {
-              fail("CentOS/RHEL < 5 and >= 7 is not supported: ${::operatingsystemmajrelease}")
+              fail("CentOS/RHEL < 5 and > 7 is not supported: ${::operatingsystemmajrelease}")
             }
           }
         }

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -11,6 +11,7 @@
 class razor::tftp inherits razor {
   # Validation
   validate_string($::razor::server_hostname)
+  validate_string($::razor::server_http_port)
 
   #Root directory
   if ($::razor::tftp_root == undef) {
@@ -31,7 +32,7 @@ class razor::tftp inherits razor {
   }
 
   # bootstrap.ipxe
-  wget::fetch { "http://${::razor::server_hostname}:8080/api/microkernel/bootstrap":
+  wget::fetch { "http://${::razor::server_hostname}:${::razor::server_http_port}/api/microkernel/bootstrap":
     destination => "${directory}/bootstrap.ipxe",
   } ->
 


### PR DESCRIPTION
This is an incomplete fix as it parameterizes the http_server_port but does not configure razor to use it. It's a short-term fix to just make port 8150 (the new default) settable so the tftp bootstrap stuff will work. My brain started hurting when I tried to find all the places the port number is referenced in the razor installation scripts; it seems env[RAZOR_HTTP_PORT] is the only place that overrides the default.
