### PR TITLE
Metadata bad name error for reidmv/yamlfile dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6.5",
-	"7.2"
+        "7.2"
       ]
     },
     {
@@ -31,6 +31,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.0.0"
+    },
+    {
+      "name": "reidmv/yamlfile",
+      "version_requirement": ">=0.2.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,8 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6.5"
+        "6.5",
+	"7.2"
       ]
     },
     {
@@ -30,10 +31,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.0.0"
-    },
-    {
-      "name": "reidmv/puppet-module-yamlfile",
-      "version_requirement": ">=0.2.0"
     }
   ]
 }


### PR DESCRIPTION
At some point (I'm running 3.8.7) puppet changed the rules for module names to no longer allow hypens in them. reidmv renamed his [yamlfile](https://forge.puppet.com/reidmv/yamlfile) module to follow the new rules. This is just syncing up that changed named in metadata.json since otherwise `puppet module build` fails. I've also taken the liberty of adding 7.2 as a supported CentOS release.

(Please ignore the mess of commits leading up to this PR; I lack git skills.)
