### PR TITLE
WIP: Adding support for razor API behind HTTPS

### DIFF
--- a/lib/facter/razorserver.rb
+++ b/lib/facter/razorserver.rb
@@ -5,29 +5,32 @@
 
 require 'facter'
 
-if Facter.value(:kernel) == "Linux" 
+if Facter.value(:kernel) == "Linux"
   Facter.add('razorserver') do
     confine :kernel => :Linux
-  
-    begin                
-      # Check which ports are in use 
-      port8150_s = `/bin/netstat -ln | /bin/grep 8150 | /usr/bin/wc -l`
-      port8150 = port8150_s.gsub(/\s+/, "").to_i
-      
-      if port8150 > 0
-        razor = `/usr/local/bin/razor -u http://localhost:8150/api -v | /bin/grep "Razor Server version"`
-      else
-        port8080_s = `/bin/netstat -ln | /bin/grep 8080 | /usr/bin/wc -l`
-        port8080 = port8080_s.gsub(/\s+/, "").to_i
-        
-        if port8080 > 0
-          razor = `/usr/local/bin/razor -u http://localhost:8080/api -v | /bin/grep "Razor Server version"`
+
+    begin
+      # Check if razor client exists
+      if File.exist? '/usr/local/bin/razor'
+      # Check which ports are in use
+        port8150_s = `/bin/netstat -ln | /bin/grep 8150 | /usr/bin/wc -l`
+        port8150 = port8150_s.gsub(/\s+/, "").to_i
+
+        if port8150 > 0
+          razor = `/usr/local/bin/razor -u http://localhost:8150/api -v | /bin/grep "Razor Server version"`
         else
-          razor = ""
-        end          
+          port8080_s = `/bin/netstat -ln | /bin/grep 8080 | /usr/bin/wc -l`
+          port8080 = port8080_s.gsub(/\s+/, "").to_i
+
+          if port8080 > 0
+            razor = `/usr/local/bin/razor -u http://localhost:8080/api -v | /bin/grep "Razor Server version"`
+          end
+        end
+      else
+        razor = ""
       end
 
-      if razor =~ /Razor Server version: (.*)/          
+      if razor =~ /Razor Server version: (.*)/
         matchdata = razor.match(/Razor Server version: (.*)/)
         version = matchdata[1]
       else
@@ -37,14 +40,14 @@ if Facter.value(:kernel) == "Linux"
       puts "Error while fetching Razor Server version: #{errors.inspect} "
       version = nil
     end
-    
+
     # Create Facts
     razorserver_facts = {}
-      
-    if version then    
+
+    if version then
       razorserver_facts[:version] = version
     end
-    
+
     setcode { razorserver_facts }
   end
 end

--- a/lib/puppet/provider/razor_rest.rb
+++ b/lib/puppet/provider/razor_rest.rb
@@ -7,21 +7,21 @@ end
 
 class Puppet::Provider::Rest < Puppet::Provider
   desc "Razor API REST calls"
-  
+
   confine :feature => :json
   confine :feature => :rest_client
-  
+
   def initialize(value={})
     super(value)
     @property_flush = {} 
   end
-  
+
   def self.get_rest_info
     config_file = "/etc/razor/api.yaml"
 
-    data = File.read(config_file) or raise "Could not read setting file #{config_file}"    
+    data = File.read(config_file) or raise "Could not read setting file #{config_file}"
     yamldata = YAML.load(data)
-    
+
     if yamldata.include?('hostname')
       hostname = yamldata['hostname']
     else
@@ -51,15 +51,15 @@ class Puppet::Provider::Rest < Puppet::Provider
     else
       private_key = "/etc/puppetlabs/puppet/ssl/private_keys/#{hostname}.pem"
     end
-    
+
     if yamldata.include?('ca_cert')
       ca_cert = yamldata['ca_cert']
     else
       ca_cert = '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
     end
-    
+
     # TODO - Shiro Authentication
-        
+
     { :ip   => hostname,
       :port => port,
       :http => http,
@@ -67,39 +67,39 @@ class Puppet::Provider::Rest < Puppet::Provider
       :private_key => private_key,
       :ca_cert => ca_cert }
   end
-  
-  def exists?    
+
+  def exists?
     @property_hash[:ensure] == :present
   end
-  
+
   def create
     @property_flush[:ensure] = :present
   end
 
-  def destroy        
+  def destroy
     @property_flush[:ensure] = :absent
   end
-        
-  def self.prefetch(resources)        
+
+  def self.prefetch(resources)
     instances.each do |prov|
       if resource = resources[prov.name]
         resource.provider = prov
       end
     end
-  end  
-  
-  def self.get_objects(type)    
+  end
+
+  def self.get_objects(type)
     rest = get_rest_info
     url = "#{rest[:http]}://#{rest[:ip]}:#{rest[:port]}/api/collections/#{type}"
-    
+
     responseJson = get_json_from_url(url)
 
     items = responseJson["items"]
 
-    objects = items.collect do |item|       
+    objects = items.collect do |item|
       get_object(item['name'], item['id'])
-    end    
-    
+    end
+
     Puppet.debug("Retrieved #{type} from REST API: #{objects}")
 
     objects
@@ -121,7 +121,7 @@ class Puppet::Provider::Rest < Puppet::Provider
       rest = ssl_rest.post(resourceHash.to_json, :content_type => 'application/json')
     else
       rest = RestClient.post url, resourceHash.to_json, :content_type => :json
-
+    end
 
     begin
     rest

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -16,7 +16,7 @@
 class razor::api (
   String $hostname = 'localhost',
   Variant[Undef, Integer] $port = undef,
-  Variant[String, Enum['http', 'https']] $http_method = 'http',
+  Enum['http', 'https'] $http_method = 'http',
   Variant[Undef, String] $client_cert = undef,
   Variant[Undef, String] $private_key = undef,
   Variant[Undef, String] $ca_cert = undef,

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -22,7 +22,7 @@ class razor::api (
   Variant[Undef, String] $ca_cert = undef,
   String $rest_client_version   = present,
   String $gem_provider          = 'puppet_gem'
-  
+
   # TODO - Shiro Authentication
 ) {
   # Parameters

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -16,6 +16,10 @@
 class razor::api (
   String $hostname = 'localhost',
   Variant[Undef, Integer] $port = undef,
+  Variant[String, Enum['http', 'https']] $http_method = 'http',
+  Variant[Undef, String] $client_cert = undef,
+  Variant[Undef, String] $private_key = undef,
+  Variant[Undef, String] $ca_cert = undef,
   # TODO - Shiro Authentication
 ) {
   # Parameters

--- a/templates/api.yaml.erb
+++ b/templates/api.yaml.erb
@@ -1,3 +1,15 @@
 ---
 hostname: <%= @hostname %>
 api_port: <%= @api_port %>
+<% if @http_method -%>
+http_method: <%= @http_method %>
+<% end -%>
+<% if @client_cert -%>
+client_cert: <%= @client_cert %>
+<% end -%>
+<% if @private_key -%>
+private_key: <%= @private_key %>
+<% end -%>
+<% if @ca_cert -%>
+ca_cert: <%= @ca_cert %>
+<% end -%>

--- a/templates/api.yaml.erb
+++ b/templates/api.yaml.erb
@@ -1,9 +1,7 @@
 ---
 hostname: <%= @hostname %>
 api_port: <%= @api_port %>
-<% if @http_method -%>
 http_method: <%= @http_method %>
-<% end -%>
 <% if @client_cert -%>
 client_cert: <%= @client_cert %>
 <% end -%>


### PR DESCRIPTION
I modified the rest call to add supported HTTPS methods along with a way to specify in the API certs etc using the existing contructs you provided.

This allows anyone running razor with an ssl cert in front of the API to use this module.