### PR TITLE
Refactor razorserver fact to not throw errors

### DIFF
--- a/lib/facter/razorserver.rb
+++ b/lib/facter/razorserver.rb
@@ -3,48 +3,39 @@
 #
 # Copyright (c) 2017 Nicolas Truyens <nicolas@truyens.com>
 
-require 'facter'
+Facter.add('razorserver') do
+  confine :kernel => :Linux
 
-if Facter.value(:kernel) == "Linux" 
-  Facter.add('razorserver') do
-    confine :kernel => :Linux
-  
-    begin                
-      # Check which ports are in use 
-      port8150_s = `/bin/netstat -ln | /bin/grep 8150 | /usr/bin/wc -l`
-      port8150 = port8150_s.gsub(/\s+/, "").to_i
-      
+  setcode do
+    begin
+      # Check which ports are in use
+      port8150_s = Facter::Core::Execution.exec('/bin/netstat -ln | /bin/grep 8150 | /usr/bin/wc -l')
+      port8150 = port8150_s.gsub(/\s+/, '').to_i
+
       if port8150 > 0
-        razor = `/usr/local/bin/razor -u http://localhost:8150/api -v | /bin/grep "Razor Server version"`
+        razor = Facter::Core::Execution.exec('/usr/local/bin/razor -u http://localhost:8150/api -v | /bin/grep "Razor Server version"')
       else
-        port8080_s = `/bin/netstat -ln | /bin/grep 8080 | /usr/bin/wc -l`
-        port8080 = port8080_s.gsub(/\s+/, "").to_i
-        
-        if port8080 > 0
-          razor = `/usr/local/bin/razor -u http://localhost:8080/api -v | /bin/grep "Razor Server version"`
-        else
-          razor = ""
-        end          
+        port8080_s = Facter::Core::Execution.exec('/bin/netstat -ln | /bin/grep 8080 | /usr/bin/wc -l')
+        port8080 = port8080_s.gsub(/\s+/, '').to_i
+
+        razor = if port8080 > 0
+                  Facter::Core::Execution.exec('/usr/local/bin/razor -u http://localhost:8080/api -v | /bin/grep "Razor Server version"')
+                else
+                  ''
+                end
       end
 
-      if razor =~ /Razor Server version: (.*)/          
-        matchdata = razor.match(/Razor Server version: (.*)/)
-        version = matchdata[1]
-      else
-        version = nil
-      end
+      version = razor.match(/Razor Server version: (.*)/)[1] if razor =~ /Razor Server version: (.*)/
     rescue
       puts "Error while fetching Razor Server version: #{errors.inspect} "
       version = nil
     end
-    
+
     # Create Facts
     razorserver_facts = {}
-      
-    if version then    
-      razorserver_facts[:version] = version
-    end
-    
-    setcode { razorserver_facts }
+
+    razorserver_facts[:version] = version if version
+
+    razorserver_facts
   end
 end


### PR DESCRIPTION
Prior to this, the razorserver fact would throw the following
message during Puppet runs on all Linux nodes:

`sh: /usr/local/bin/razor: No such file or directory`

This fixes that by wrapping all of the shell commands in the recommended
Facter::Core::Execution.exec methods which helps to catch errors and is
generally safer then using backticks to execute commands.

The fact has also been refactored for Ruby style (according to rubocop)
and Facter recommendations (fixed the use of confine, put everything
inside of the setcode block, etc...).

ping @Lavaburn 