### PR TITLE
Fix nil issues

### DIFF
--- a/lib/puppet/provider/razor_rest.rb
+++ b/lib/puppet/provider/razor_rest.rb
@@ -97,6 +97,7 @@ class Puppet::Provider::Rest < Puppet::Provider
     rescue => e
       Puppet.debug "Razor REST response: "+e.inspect
       Puppet.warning "Unable to contact Razor Server through REST interface (#{url})"
+      return nil
     end
   
     begin

--- a/lib/puppet/provider/razor_rest.rb
+++ b/lib/puppet/provider/razor_rest.rb
@@ -102,7 +102,7 @@ class Puppet::Provider::Rest < Puppet::Provider
     begin
       responseJson = JSON.parse(response)
     rescue
-      raise "Could not parse the JSON response from Razor: " + response
+      raise "Could not parse the JSON response from Razor: #{response}"
     end
   
     responseJson


### PR DESCRIPTION
When the razor server is not yet up, or otherwise unresponsive requests return nil, causing the puppet run to break and not install or launch razor.