### PR TITLE
Update the default puppet gem to a supported version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
 	
 	gem "parallel_tests"
 	
-	gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.3.2'
+	gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.6.0'
 	gem "puppetlabs_spec_helper"
 	
 	gem "r10k"		


### PR DESCRIPTION
Puppet 4.3.2 doesn't pass the spec tests (run locally).