### PR TITLE
Add support for debian 8 and 9

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,12 +44,14 @@ class razor::server inherits razor {
         }
         'Debian': {
           case $::lsbdistcodename {
-            'squeeze','wheezy': {
+            'squeeze','wheezy','jessie','stretch': {
               # Squeeze (6) - OK
               # Wheezy (7) - OK
+              # Jessie (8) - OK
+              # Stretch (9) - OK
             }
             default: {
-              fail("Debian < 6 and > 8 is not supported: ${::lsbdistcodename}")
+              fail("Debian < 6 and > 10 is not supported: ${::lsbdistcodename}")
             }
           }
         }


### PR DESCRIPTION
Since 2019-08-29, packages for debian jessie (http://apt.puppetlabs.com/pool/jessie/puppet/r/) and stretch (http://apt.puppetlabs.com/pool/stretch/puppet/r/).
This PR updates checks to include those OSes.