### PR TITLE
Hook deployment

### DIFF
--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -1,0 +1,25 @@
+# == Definition: razor::hook
+#
+# Razor Provisioning: Hook
+#
+# === Authors
+#
+# Nicolas Truyens <nicolas@truyens.com>
+#
+define razor::hook (
+  String $module    = 'razor',
+  String $directory = 'hooks',
+  String $root      = "${::razor::data_root_path}/hooks",
+) {
+  # Validation
+  validate_absolute_path($root)
+
+  # Create directory
+  Package[$::razor::server_package_name]
+  ->
+  file { "${root}/${name}.hook":
+    ensure  => 'directory',
+    source  => "puppet:///modules/${module}/${directory}/${name}.hook",
+    recurse => true,
+  }
+}

--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -18,8 +18,11 @@ define razor::hook (
   Package[$::razor::server_package_name]
   ->
   file { "${root}/${name}.hook":
-    ensure  => 'directory',
-    source  => "puppet:///modules/${module}/${directory}/${name}.hook",
-    recurse => true,
+    ensure             => 'directory',
+    source             => "puppet:///modules/${module}/${directory}/${name}.hook",
+    recurse            => true,
+    owner              => 'root',
+    group              => 'root',
+    source_permissions => 'use',
   }
 }

--- a/spec/defines/hook_spec.rb
+++ b/spec/defines/hook_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'razor::hook', :type => :define do
+  Puppet::Util::Log.level = :warning
+  Puppet::Util::Log.newdestination(:console)
+
+  on_supported_os(
+    :supported_os => [
+      {
+        "operatingsystem" => "Ubuntu",
+        "operatingsystemrelease" => [
+          "14.04",
+          "16.04"
+        ]
+      },
+      {
+        "operatingsystem" => "CentOS",
+        "operatingsystemrelease" => [
+          "6.5",
+          "7.0.1406"
+        ]
+      },
+    ]
+  ).each do |os, facts|  
+    context "on #{os}" do        
+      let(:facts) { 
+        facts
+      }
+        
+      let(:title) { 'puppetcert' }
+      
+      context "defaults" do    
+        let(:pre_condition) { 
+          dependencies() + razor_default()
+        }
+        
+        it { should compile.with_all_deps }
+          
+        it { should contain_file('/opt/razor/hooks/puppetcert.hook').with(
+          'source' => "puppet:///modules/razor/hooks/puppetcert.hook"
+        ) }
+      end
+      
+      context "aio_support" do    
+        let(:pre_condition) { 
+          dependencies() + razor_default_aio()
+        }
+        
+        it { should compile.with_all_deps }
+          
+        it { should contain_file('/opt/puppetlabs/server/apps/razor-server/share/razor-server/hooks/puppetcert.hook').with(
+          'source' => "puppet:///modules/razor/hooks/puppetcert.hook"
+        ) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows for deployment of hooks in the same way broker files are being provisioned.